### PR TITLE
Fixing error when looking for Scope annotation

### DIFF
--- a/feign-cdi/src/main/java/feign/cdi/impl/AnnotatedFeignClientBean.java
+++ b/feign-cdi/src/main/java/feign/cdi/impl/AnnotatedFeignClientBean.java
@@ -89,8 +89,8 @@ class AnnotatedFeignClientBean implements Bean<Object> {
     @Override
     public Class<? extends Annotation> getScope() {
         for(Annotation annotation : interfaceClass.getAnnotations()) {
-            if(annotation.getClass().getAnnotation(Scope.class) != null) {
-                return annotation.getClass();
+            if(annotation.annotationType().getAnnotation(Scope.class) != null) {
+                return annotation.annotationType();
             }
         }
         return Dependent.class;


### PR DESCRIPTION
This PR fixes an error when looking up for the `Scope` annotation. Calling getClass() on an annotation may return a proxy class instead of wanted class.

Thank you